### PR TITLE
Add phase at position

### DIFF
--- a/lib/phase-list.js
+++ b/lib/phase-list.js
@@ -68,6 +68,11 @@ PhaseList.prototype._resolveNameAndAddToMap = function(phaseOrName) {
     phase = new Phase(phase);
   }
 
+  if (phase.id in this._phaseMap) {
+    throw new Error('Phase "' + phase.id + '" already exists.');
+  }
+
+
   if(!phase.__isPhase__) {
     throw new Error('Cannot add a non phase object to a PhaseList');
   }

--- a/test/phase-list.test.js
+++ b/test/phase-list.test.js
@@ -43,6 +43,12 @@ describe('PhaseList', function() {
       expect(foo.id).to.equal('foo');
       expect(bar.id).to.equal('bar');
     });
+
+    it('should throw when adding an existing phase', function() {
+      phaseList.add('a-name');
+      expect(function() { phaseList.add('a-name'); })
+        .to.throw(/a-name/);
+    });
   });
 
   describe('phaseList.remove(phaseName)', function() {


### PR DESCRIPTION
Implement the following methods for adding new phases at a given
position:
- `phases.addAt(index, phase)`
- `phases.addBefore(name, phase)`
- `phases.addAfter(name, phase)`

The first commit cleans up the unit tests.

/to @ritch please review
