### PR TITLE
Add an option to create Phases that run handlers in serial

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ second.use(function(ctx, cb) {
   cb();
 });
 
-phases.run();
+phases.run(ctx);
 ```
 
 See [API docs](http://apidocs.strongloop.com/loopback-phase/) for

--- a/lib/phase.js
+++ b/lib/phase.js
@@ -5,22 +5,46 @@ module.exports = Phase;
 /**
  * A slice of time in an application. Provides hooks to allow
  * functions to be executed before, during and after, the defined slice.
+ * Handlers can be registered to a phase using `before()`, `use()`, or `after()`
+ * so that they are placed into one of the three stages.
  *
  * ```js
  * var Phase = require('loopback-phase').Phase;
- * var myPhase = new Phase('my-phase');
+ *
+ * // Create a phase without id
+ * var anonymousPhase = new Phase();
+ *
+ * // Create a named phase
+ * var myPhase1 = new Phase('my-phase');
+ *
+ * // Create a named phase with id & options
+ * var myPhase2 = new Phase('my-phase', {parallel: true});
+ *
+ * // Create a named phase with options only
+ * var myPhase3 = new Phase({id: 'my-phase', parallel: true});
+ *
  * ```
  *
  * @class Phase
  *
- * @prop {Phase} next The `Phase` to be executed after this `Phase`.
  * @prop {String} id The name or identifier of the `Phase`.
+ * @prop {Object} options The options to configure the `Phase`
  *
- * @param {String} id The name or identifier of the `Phase`.
+ * @param {String} [id] The name or identifier of the `Phase`.
+ * @options {Object} [options] Options for the `Phase`
+ * @property {String} [id] The name or identifier of the Phase
+ * @property {Boolean} [parallel] To execute handlers in the same stage
+ * in parallel
+ * @end
  */
 
-function Phase(id) {
+function Phase(id, options) {
+  if (typeof id === 'object' && options === undefined) {
+    options = id;
+    id = options.id;
+  }
   this.id = id;
+  this.options = options || {};
   this.handlers = [];
   this.beforeHandlers = [];
   this.afterHandlers = [];
@@ -28,10 +52,9 @@ function Phase(id) {
 
 /**
  * Register a phase handler. The handler will be executed
- * once the phase is launched. Handlers will be executed
- * in parralel and must callback once complete. If the
- * handler calls back with an error, the phase will immediately
- * hault execution and call the callback provided to
+ * once the phase is launched. Handlers must callback once
+ * complete. If the handler calls back with an error, the phase will immediately
+ * halt execution and call the callback provided to
  * `phase.run(callback)`.
  *
  * **Example**
@@ -58,7 +81,7 @@ Phase.prototype.use = function(handler) {
 
 /**
  * Register a phase handler to be executed before the phase begins.
- * See `register()` for an example.
+ * See `use()` for an example.
  *
  * @param {Function} handler
  */
@@ -70,7 +93,7 @@ Phase.prototype.before = function(handler) {
 
 /**
  * Register a phase handler to be executed after the phase completes.
- * See `register()` for an example.
+ * See `use()` for an example.
  *
  * @param {Function} handler
  */
@@ -85,34 +108,42 @@ Phase.prototype.after = function(handler) {
  * a context object to be passed as the first argument for each handler
  * function.
  *
+ * The handlers are executed in serial stage by stage: beforeHandlers, handlers,
+ * and afterHandlers. Handlers within the same stage are executed in serial by
+ * default and in parallel only if the options.parallel is true,
+ *
  * @param {Object} [context] The scope applied to each handler function.
  * @callback {Function} callback
- * @param {Error} err Any `Error` that occured during the execution of
+ * @param {Error} err Any `Error` that occurs during the execution of
  * the phase.
  */
 
 Phase.prototype.run = function(ctx, cb) {
-  if(typeof ctx === 'function') {
+  if (typeof ctx === 'function') {
     cb = ctx;
     ctx = {};
   }
 
-  var steps = [
-    async.apply(async.parallel, bind(this.beforeHandlers, ctx)),
-    async.apply(async.parallel, bind(this.handlers, ctx)),
-    async.apply(async.parallel, bind(this.afterHandlers, ctx))
-  ];
+  var self = this;
+  // Run a single handler with ctx
+  function runHandler(handler, done) {
+    handler(ctx, done);
+  }
 
-  async.series(steps, cb);
+  // Run an array of handlers with ctx
+  function runHandlers(handlers, done) {
+    // Only run the handlers in parallel if the options.parallel is true
+    if (self.options.parallel) {
+      async.each(handlers, runHandler, done);
+    } else {
+      async.eachSeries(handlers, runHandler, done);
+    }
+  }
+
+  async.eachSeries([this.beforeHandlers, this.handlers, this.afterHandlers],
+    runHandlers, cb);
 };
 
-function bind(handlers, ctx) {
-  return handlers.map(function(handler) {
-    return function(cb) {
-      handler(ctx, cb);
-    };
-  });
-}
 
 /**
  * Return the `Phase` as a string.


### PR DESCRIPTION
/to @ritch @bajtos 

The PR adds an option (`options.serial`) to allow handlers in the same stage of a phase to be executed in serial and refactor the `run()` method to reduce number of closures.

Here is the issue that I ran into with oAuth2 component.

We have 3 middleware: 
1. express session (create/restore req.session)
2. passport.initialize (sets req.session to req._passport.session)
3. passport.session (depends on 2)

All of them are session related and have to come in order. It makes sense to register 1 with `session` phase.
Then I have to squeeze 2&3 into `session:after`.

I could introduce more phases around session, such as 'session-creation', 'session-auth'. Just wonder if that would lead too many phases. 
