### PR TITLE
phase-list: implement `.zipMerge(names)`

### DIFF
--- a/lib/phase-list.js
+++ b/lib/phase-list.js
@@ -154,6 +154,66 @@ PhaseList.prototype.remove = function(phase) {
 };
 
 /**
+ * Merge the provided list of names with the existing phases
+ * in such way that the order of phases is preserved.
+ *
+ * **Example**
+ *
+ * ```js
+ * // Initial list of phases
+ * phaseList.add(['initial', 'session', 'auth', 'routes', 'files', 'final']);
+ *
+ * // zip-merge more phases
+ * phaseList.zipMerge([
+ *   'initial', 'postinit', 'preauth', 'auth',
+ *   'routes', 'subapps', 'final', 'last'
+ * ]);
+ *
+ * // print the result
+ * console.log('Result:', phaseList.getPhaseNames());
+ * // Result: [
+ * //   'initial', 'postinit', 'preauth', 'session', 'auth',
+ * //   'routes', 'subapps', 'files', 'final', 'last'
+ * // ]
+ * ```
+ *
+ * @param {String[]} names List of phase names to zip-merge
+ */
+PhaseList.prototype.zipMerge = function(names) {
+  if (!names.length) return;
+
+  var targetPhases = this.getPhaseNames();
+  var targetIx = targetPhases.indexOf(names[0]);
+
+  if (targetIx === -1) {
+    // the first new phase does not match any existing one
+    // start adding the new phases at the start of the list
+    this.addAt(0, names[0]);
+    targetIx = 0;
+  }
+
+  // merge (zip) two arrays of phases
+  for (var sourceIx = 1; sourceIx < names.length; sourceIx++) {
+    var nameToAdd = names[sourceIx];
+    var previousPhase = names[sourceIx - 1];
+    var existingIx = targetPhases.indexOf(nameToAdd, targetIx);
+    if (existingIx === -1) {
+      // A new phase - try to add it after the last one,
+      // unless it was already registered
+      if (targetPhases.indexOf(nameToAdd) !== -1) {
+        throw new Error('Phase ordering conflict: cannot add "' + nameToAdd +
+        '" after "' + previousPhase + '", because the opposite order was ' +
+        ' already specified');
+      }
+      this.addAfter(previousPhase, nameToAdd);
+    } else {
+      // An existing phase - move the pointer
+      targetIx = existingIx;
+    }
+  }
+};
+
+/**
  * Find a `Phase` from the list.
  *
  * @param {String} id The phase identifier

--- a/test/phase-list.test.js
+++ b/test/phase-list.test.js
@@ -156,4 +156,34 @@ describe('PhaseList', function() {
         .to.throw(/unknown-phase/);
     });
   });
+
+  describe('phaseList.zipMerge(phases)', function() {
+    it('merges phases preserving the order', function() {
+      phaseList.add(['initial', 'session', 'auth', 'routes', 'files', 'final']);
+      phaseList.zipMerge([
+        'initial',
+        'postinit', 'preauth', // add
+        'auth', 'routes',
+        'subapps', // add
+        'final',
+        'last' // add
+      ]);
+
+      expect(phaseList.getPhaseNames()).to.eql([
+        'initial',
+        'postinit', 'preauth', // new
+        'session', 'auth', 'routes',
+        'subapps', // new
+        'files', 'final',
+        'last' // new
+      ]);
+    });
+
+    it('starts adding phases from the start', function() {
+      phaseList.add(['start', 'end']);
+      phaseList.zipMerge(['first', 'end', 'last']);
+      expect(phaseList.getPhaseNames())
+        .to.eql(['first', 'start', 'end', 'last']);
+    });
+  });
 });


### PR DESCRIPTION
The new method merges the provided list of names with the existing
phases in such way that the order of phases is preserved.

Example:

```
// Initial list of phases
phaseList.add(['initial', 'session', 'auth',
  'routes', 'files', 'final']);

// zip-merge more phases
phaseList.zipMerge([
  'initial', 'postinit', 'preauth', 'auth',
  'routes', 'subapps', 'final', 'last'
]);

// print the result
console.log('Result:', phaseList.getPhaseNames());
```

Output:

```
Result: [
  'initial', 'postinit', 'preauth', 'session', 'auth',
  'routes', 'subapps', 'files', 'final', 'last'
]
```

See also strongloop/loopback#786.

/to @ritch please review
/cc @raymondfeng 
