### PR TITLE
Add "phaseList.registerHandler"

### DIFF
--- a/lib/phase-list.js
+++ b/lib/phase-list.js
@@ -263,3 +263,34 @@ PhaseList.prototype.getPhaseNames = function() {
     return phase.id;
   });
 };
+
+/**
+ * Register a phase handler for the given phase (and sub-phase).
+ *
+ * **Example**
+ *
+ * ```js
+ * // register via phase.use()
+ * phaseList.registerHandler('routes', function(ctx, next) { next(); });
+ * // register via phase.before()
+ * phaseList.registerHandler('auth:before', function(ctx, next) { next(); });
+ * // register via phase.after()
+ * phaseList.registerHandler('auth:after', function(ctx, next) { next(); });
+ * ```
+ *
+ * @param {String} phaseName Name of an existing phase, optionally with
+ *   ":before" or ":after" suffix.
+ * @param {Function(Object, Function)} handler The handler function to register
+ *   with the given phase.
+ */
+PhaseList.prototype.registerHandler = function(phaseName, handler) {
+  var subphase = 'use';
+  var m = phaseName.match(/^(.+):(before|after)$/);
+  if (m) {
+    phaseName = m[1];
+    subphase = m[2];
+  }
+  var phase = this.find(phaseName);
+  if (!phase) throw new Error('Unknown phase ' + phaseName);
+  phase[subphase](handler);
+};

--- a/test/phase-list.test.js
+++ b/test/phase-list.test.js
@@ -186,4 +186,26 @@ describe('PhaseList', function() {
         .to.eql(['first', 'start', 'end', 'last']);
     });
   });
+
+  describe('phaseList.registerHandler', function() {
+    var NOOP_HANDLER = function(ctx, next) { next(); };
+
+    it('adds handler to the correct phase', function() {
+      phaseList.add(['one', 'two']);
+      phaseList.registerHandler('one', NOOP_HANDLER);
+      expect(phaseList.find('one').handlers).to.eql([NOOP_HANDLER]);
+    });
+
+    it('supports ":before" suffix', function() {
+      phaseList.add('main');
+      phaseList.registerHandler('main:before', NOOP_HANDLER);
+      expect(phaseList.find('main').beforeHandlers).to.eql([NOOP_HANDLER]);
+    });
+
+    it('supports ":after" suffix', function() {
+      phaseList.add('main');
+      phaseList.registerHandler('main:after', NOOP_HANDLER);
+      expect(phaseList.find('main').afterHandlers).to.eql([NOOP_HANDLER]);
+    });
+  });
 });


### PR DESCRIPTION
The new method is a syntactic sugar to prevent [Train Wreck anti-pattern](http://c2.com/cgi/wiki?TrainWreck) and make it easier to loopback-phase consumers to support string-encoded subphases like "main:before" and "main:after".

Connect to strongloop-internal/scrum-loopback#729

/to @ritch please review