### PR TITLE
Drop support for Node.js 4.x + update dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
   - "6"
   - "8"
+  - "10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
-  - "4"
   - "6"
   - "8"

--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
   },
   "license": "MIT",
   "dependencies": {
-    "async": "^0.9.0",
-    "debug": "^2.1.0",
-    "strong-globalize": "^3.1.0"
+    "async": "^2.6.1",
+    "debug": "^3.1.0",
+    "strong-globalize": "^4.1.1"
   },
   "devDependencies": {
-    "chai": "~1.10.0",
-    "jshint": "^2.5.10",
+    "chai": "^4.1.2",
     "express": "^4.0.0",
-    "mocha": "^2.0.1"
+    "jshint": "^2.5.10",
+    "mocha": "^5.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.1.0",
   "description": "Hook into a LoopBack application's phases",
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "keywords": [
     "StrongLoop",


### PR DESCRIPTION
- Drop support for Node 4.x
- Travis: add Node.js 10.x to the build matrix
- Disable package-lock feature of npm
- Update dependencies
